### PR TITLE
Allow tweaking environment of run_audit.sh script

### DIFF
--- a/run_audit.sh
+++ b/run_audit.sh
@@ -17,9 +17,9 @@
 # lower case variables are discovered or built from other variables
 
 # Goss host Variables
-AUDIT_BIN=/usr/local/bin/goss  # location of the goss executable
-AUDIT_FILE=goss.yml  # the default goss file used by the audit provided by the audit configuration
-AUDIT_CONTENT_LOCATION=/var/tmp  # Location of the audit configuration file as available to the OS
+AUDIT_BIN="${AUDIT_BIN:-/usr/local/bin/goss}"  # location of the goss executable
+AUDIT_FILE="${AUDIT_FILE:-goss.yml}"  # the default goss file used by the audit provided by the audit configuration
+AUDIT_CONTENT_LOCATION="${AUDIT_CONTENT_LOCATION:-/var/tmp}"  # Location of the audit configuration file as available to the OS
 
 
 # Goss benchmark variables (these should not need changing unless new release)

--- a/section_4/cis_4.2.3/cis_4.2.3.yml
+++ b/section_4/cis_4.2.3/cis_4.2.3.yml
@@ -2,7 +2,7 @@
 command:
   logfile_configured:
     title: 4.2.3 | Ensure permissions on all logfiles are configured
-    exec: find /var/log/ -type f -perm /g+wx,o+rwx -exec ls -l "{}""+
+    exec: 'find /var/log/ -type f -perm /g+wx,o+rwx -exec ls -l "{}" +'
     exit-status: 0
     stdout: ['!/./']
     meta:

--- a/section_4/cis_4.2.3/cis_4.2.3.yml
+++ b/section_4/cis_4.2.3/cis_4.2.3.yml
@@ -2,7 +2,7 @@
 command:
   logfile_configured:
     title: 4.2.3 | Ensure permissions on all logfiles are configured
-    exec: 'find /var/log/ -type f -perm /g+wx,o+rwx -exec ls -l "{}" +'
+    exec: find /var/log/ -type f -perm /g+wx,o+rwx -exec ls -l "{}""+
     exit-status: 0
     stdout: ['!/./']
     meta:


### PR DESCRIPTION
# Pull request details

**Overall Review of Changes:**

Allow tweaking environment of run_audit.sh script. It is related to the issue created in [RHEL8-CIS](https://github.com/ansible-lockdown/RHEL8-CIS/issues/186
) repository

**Issue Fixes:**
https://github.com/ansible-lockdown/RHEL8-CIS/issues/186

**Enhancements:**
Changes in this PR do not modify default functionality and only allow for modifying previously static values in `run_audit.sh`.

**How has this been tested?:**
It has been tested by setting [audit_out_dir](https://github.com/ansible-lockdown/RHEL8-CIS/blob/c8883b9964f13c02f49e61121734ef678041cc6d/defaults/main.yml#L694) to something other than default value. 