### PR TITLE
Fix version comparison

### DIFF
--- a/run_audit.sh
+++ b/run_audit.sh
@@ -147,14 +147,16 @@ export FAILURE=0
 if [ -s "${AUDIT_BIN}" ]; then
   echo "OK - Audit binary $AUDIT_BIN is available"
   goss_installed_version="$($AUDIT_BIN -v | awk '{print $NF}' | cut -dv -f2)"
-  ver_calc=$(awk 'BEGIN{print $goss_installed_version < $AUDIT_BIN_MIN_VER}')
-  if [ $AUDIT_BIN_MIN_VER = "$goss_installed_version" ] || [ "$ver_calc" = 1 ] ; then
-  echo "OK - Goss is installed and Version is ok";
+  newer_version=$(echo -e "$goss_installed_version\n$AUDIT_BIN_MIN_VER" | sort -V | tail -n 1)
+  if [ "$goss_installed_version" = "$newer_version" ] || [ "$goss_installed_version" = "$AUDIT_BIN_MIN_VER" ]; then
+    echo "OK - Goss is installed and version is ok ($goss_installed_version >= $AUDIT_BIN_MIN_VER)"
   else
-  echo "WARNING - Goss installed = ${goss_installed_version}, does not met minimum of ${AUDIT_BIN_MIN_VER}"; export FAILURE=2
+    echo "WARNING - Goss installed = ${goss_installed_version}, does not met minimum of ${AUDIT_BIN_MIN_VER}"
+    export FAILURE=2
   fi
 else
-  echo "WARNING - The audit binary is not available at $AUDIT_BIN "; export FAILURE=1
+  echo "WARNING - The audit binary is not available at $AUDIT_BIN "
+  export FAILURE=1
 fi
 
 if [ -f "${audit_content_dir}/${AUDIT_FILE}" ]; then


### PR DESCRIPTION
# Pull request details

**Overall Review of Changes:**

The version comparison failed when the currently installed goss version was more recent than the minimum version.
The awk version does not support version comparison. 
I propose to sort using the version sort by `sort` tool and adjust the logic slightly.

**Issue Fixes:**
n/a

**Enhancements:**
n/a

**How has this been tested?:**
Version comparison tested OK with goss version 0.4.2 and 0.3.21.
