### PR TITLE
Correct syntax error in run_audit.sh (#58)

### DIFF
--- a/run_audit.sh
+++ b/run_audit.sh
@@ -83,7 +83,7 @@ fi
 if [ "$(grep -Ec "rhel|oracle" /etc/os-release)" != 0 ]; then
   os_vendor="RHEL"
 else
-  os_vendor="$(hostnamectl | grep Oper | cut -d : -f2 | awk '{print $1}' | tr '[:lower:]')"
+  os_vendor="$(hostnamectl | grep Oper | cut -d : -f2 | awk '{print tolower($1)}')"
 fi
 
 os_maj_ver="$(grep -w VERSION_ID= /etc/os-release | awk -F\" '{print $2}' | cut -d '.' -f1)"


### PR DESCRIPTION
# Pull request details

**Overall Review of Changes:**

Fixing the syntax error on line 86. This is due to the wrong use of the `tr` command. I chose to use `awk` instead since it requires one pipe less than when fixing the `tr` syntax.

**Issue Fixes:**
- #58 

**Enhancements:**
None

**How has this been tested?:**
Executing the `run_audit.sh` script again in my sandbox and verifying that there's no more syntax error.
