### PR TITLE
Fix GOSS syntax for 1.3.2 UEFI mount test by adding exists: true

### DIFF
--- a/section_1/cis_1.3/cis_1.3.2.yml
+++ b/section_1/cis_1.3/cis_1.3.2.yml
@@ -28,6 +28,7 @@ command:
 mount:
   boot_efi_mask:
     title: 1.3.2 | Ensure permissions on bootloader config are configured | /boot/efi opts
+    exists: true
     mountpoint: /boot/efi
     opts:
     - 'uid=0'


### PR DESCRIPTION
# Pull request details

**Overall Review of Changes:**
Added `exists: true` to the `/boot/efi` mount check in Goss to fix false-positive failures for Rule 1.3.2 on UEFI systems. Updated the audit logic to ensure compliance with CIS RHEL 8 Benchmark Section 1.3.2.

**Issue Fixes:**
Fixes false-positive failure on 1.3.2 reported by Goss when running on UEFI systems.

**Enhancements:**
Prevents Goss syntax errors for missing required attributes.

**How has this been tested?:**
- Ran full Goss audit with all Level 1 tasks enabled, including high-disruption tasks.
- Verified 1.3.2 passes on UEFI systems and generates no syntax errors.
- Used a result splitter python script from my personal repository to filter out failed tasks easily. 
