### PR TITLE
Fix 1.3.1 allow 0700 permissions for UEFI systems

### DIFF
--- a/section_1/cis_1.3/cis_1.3.1.yml
+++ b/section_1/cis_1.3/cis_1.3.1.yml
@@ -6,7 +6,11 @@ file:
     exists: true
     owner: root
     group: root
+    {{ if .Vars.rhel8cis_legacy_boot }}
     mode: "0600"
+    {{ else }}
+    mode: "0700"
+    {{ end }}
     path: {{ .Vars.rhel8cis_boot_path }}/user.cfg
     contents:
     - '/^GRUB2_PASSWORD=grub.pbkdf2.sha512./'


### PR DESCRIPTION
# Pull request details

**Overall Review of Changes:**
Updated CIS Rule **1.3.1** to support both BIOS and UEFI bootloader configurations. The change introduces a conditional check for the `rhel8cis_legacy_boot` variable, allowing for `0600` permissions on legacy BIOS systems while correctly auditing for `0700` on UEFI systems.

To support the implementation based on RHEL 8 CIS Benchmark v3.0.0 documentation:
```
For systems using UEFI (Files located in /boot/efi/EFI/*):
- Mode is 0700 or more restrictive
For systems using BIOS (Files located in /boot/grub2/*):
- Mode is 0600 or more restrictive
```

**Issue Fixes:**
Fixes false positive failures for 1.3.1 on UEFI systems where permissions are locked at `0700` due to mount options. 

**Enhancements:**
Implemented dynamic mode detection (`0600` vs `0700`) to ensure compliance across different hardware architectures without manual overrides. 

**How has this been tested?:**
- Verified that the audit correctly passes when the bootloader config is at its default secure state of `0700`.
- Manually forced the partition to `0755` via `fstab` modification. Verified that the Goss audit failed as expected, confirming the mode check is accurately enforcing the `0700` conditional based environment. 
```
    "summary-line-compact": "File: grub_bootpass: /boot/efi/EFI/redhat//user.cfg: mode: Expected \"0755\" to equal \"0700\"",
    "title": "1.3.1 | Ensure bootloader password is set"
```

